### PR TITLE
Specify data context, to be compatible with MXNet 1.1.0 stable

### DIFF
--- a/predict.md
+++ b/predict.md
@@ -34,7 +34,8 @@ with net.name_scope():
 In the last section, we saved all parameters into a file, now let's load it back.
 
 ```{.python .input  n=3}
-net.load_params('net.params')
+from mxnet import cpu
+net.load_params('net.params', ctx=cpu())
 ```
 
 ## Predict

--- a/train.md
+++ b/train.md
@@ -134,10 +134,14 @@ def acc(output, label):
 Now we can implement the complete training loop.
 
 ```{.python .input  n=12}
+from mxnet import cpu
+
 for epoch in range(10):
     train_loss, train_acc, valid_acc = 0., 0., 0.
     tic = time()
     for data, label in train_data:
+        data = data.as_in_context(cpu())
+        label = label.as_in_context(cpu())
         # forward + backward
         with autograd.record():
             output = net(data)
@@ -151,6 +155,8 @@ for epoch in range(10):
 
     # calculate validation accuracy
     for data, label in valid_data:
+        data = data.as_in_context(cpu())
+        label = label.as_in_context(cpu())
         valid_acc += acc(net(data), label)
 
     print("Epoch %d: Loss: %.3f, Train acc %.3f, Test acc %.3f, \


### PR DESCRIPTION
1. `train.md`: In training loop, `data` and `label` must be put in CPU context by explicitly calling `.as_in_context()`. This addresses #12.
2. `predict.md`: data context must be specified for `load_params()`