### PR TITLE
Fix typos

### DIFF
--- a/autograd.md
+++ b/autograd.md
@@ -75,7 +75,7 @@ with autograd.record():
 c.backward()
 ```
 
-We know that `b` is a linear function of `a`, and `c` is chosen from `b`. Then the gradient with respect to `a` be will either `[c/a[0], 0]` or `[0, c/a[1]`, depending on which element from `b` we picked. Let's find the results:
+We know that `b` is a linear function of `a`, and `c` is chosen from `b`. Then the gradient with respect to `a` be will be either `[c/a[0], 0]` or `[0, c/a[1]]`, depending on which element from `b` we picked. Let's find the results:
 
 ```{.python .input}
 [a.grad, c/a]

--- a/nn.md
+++ b/nn.md
@@ -76,7 +76,7 @@ The usage of `nn.Sequential` is similar to `nn.Dense`. In fact, both of them are
 
 ```{.python .input}
 net.initialize()
-# Input shape is (RGB_channels, batch_size, height, width)
+# Input shape is (batch_size, color_channels, height, width)
 x = nd.random.uniform(shape=(4,1,28,28))
 y = net(x)
 y.shape

--- a/nn.md
+++ b/nn.md
@@ -30,7 +30,7 @@ x = nd.random.uniform(-1,1,(3,4))
 layer(x)
 ```
 
-As can be seen, we the layer's input limit of 2 produced a $(3,2)$ shape output from our $(3,4)$ input. Note that we didn't specify the input size of `layer` before (though we can specify it with the argument `in_units=4` here), the system will automatically infer it during the first time we feed in data, create and initialize the weights. So we can access the weight after the first forward pass:
+As can be seen, the layer's input limit of 2 produced a $(3,2)$ shape output from our $(3,4)$ input. Note that we didn't specify the input size of `layer` before (though we can specify it with the argument `in_units=4` here), the system will automatically infer it during the first time we feed in data, create and initialize the weights. So we can access the weight after the first forward pass:
 
 ```{.python .input  n=35}
 layer.weight.data()
@@ -76,7 +76,7 @@ The usage of `nn.Sequential` is similar to `nn.Dense`. In fact, both of them are
 
 ```{.python .input}
 net.initialize()
-# Input shape is (batch_size, RGB_channels, height, width)
+# Input shape is (RGB_channels, batch_size, height, width)
 x = nd.random.uniform(shape=(4,1,28,28))
 y = net(x)
 y.shape

--- a/predict.md
+++ b/predict.md
@@ -64,7 +64,7 @@ Finally, we visualize the images and compare the prediction with the ground trut
 ```{.python .input  n=15}
 _, figs = plt.subplots(1, 6, figsize=(15, 15))
 text_labels = [
-    't-shirt', 'trouser', 'pullover', 'dress,', 'coat',
+    't-shirt', 'trouser', 'pullover', 'dress', 'coat',
     'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot'
 ]
 for f,x,yi,pyi in zip(figs, X, y, preds):
@@ -80,7 +80,7 @@ plt.show()
 ## Predict with models from Gluon model zoo
 
 
-The LeNet trained on FashionMNIST is a good example to start with, but too simple to predict real-life pictures. Instead of training large-scale model from scratch, [Gluon model zoo](https://mxnet.incubator.apache.org/api/python/gluon/model_zoo.html) provides multiple pre-trained powerful models. For example, we can download and load a pre-trained ResNet-50 V2 model on the ImageNet dataset.
+The LeNet trained on FashionMNIST is a good example to start with, but too simple to predict real-life pictures. Instead of training large-scale model from scratch, [Gluon model zoo](https://mxnet.incubator.apache.org/api/python/gluon/model_zoo.html) provides multiple pre-trained powerful models. For example, we can download and load a pre-trained ResNet-50 V2 model that was trained on the ImageNet dataset.
 
 ```{.python .input  n=7}
 from mxnet.gluon.model_zoo import vision as models
@@ -110,8 +110,10 @@ x = image.imread(fname)
 ```
 
 Following the conventional way of preprocessing ImageNet data:
-1. resize the short edge into 256 pixes,
-2. then perform a center crop to obtain a 224-by-224 image
+
+1. Resize the short edge into 256 pixes,
+2. And then perform a center crop to obtain a 224-by-224 image.
+
 The following code uses the image processing functions provided in the MXNet [image module](https://mxnet.incubator.apache.org/api/python/image/image.html).
 
 ```{.python .input  n=10}

--- a/train.md
+++ b/train.md
@@ -31,7 +31,7 @@ Next, we visualize the first six examples.
 
 ```{.python .input  n=3}
 text_labels = [
-    't-shirt', 'trouser', 'pullover', 'dress,', 'coat',
+    't-shirt', 'trouser', 'pullover', 'dress', 'coat',
     'sandal', 'shirt', 'sneaker', 'bag', 'ankle boot'
 ]
 X, y = mnist_train[0:6]
@@ -110,7 +110,7 @@ Besides the neural network, we need to define the loss function and optimization
 softmax_cross_entropy = gluon.loss.SoftmaxCrossEntropyLoss()
 ```
 
-The optimization method we picked is the standard stochastic gradient descent with constant learning rate of 0.1.
+The optimization method we pick is the standard stochastic gradient descent with constant learning rate of 0.1.
 
 ```{.python .input  n=10}
 trainer = gluon.Trainer(net.collect_params(),
@@ -145,7 +145,7 @@ for epoch in range(10):
         loss.backward()
         # update parameters
         trainer.step(batch_size)
-        # calculate traing metrics
+        # calculate training metrics
         train_loss += loss.mean().asscalar()
         train_acc += acc(output, label)
 

--- a/use_gpus.md
+++ b/use_gpus.md
@@ -142,5 +142,5 @@ for epoch in range(10):
         train_loss += sum([l.sum().asscalar() for l in losses])
 
     print("Epoch %d: Loss: %.3f, Time %.1f sec" % (
-        epoch, train_loss/len(train_data), time()-tic))
+        epoch, train_loss/len(train_data)/batch_size, time()-tic))
 ```

--- a/use_gpus.md
+++ b/use_gpus.md
@@ -142,5 +142,5 @@ for epoch in range(10):
         train_loss += sum([l.sum().asscalar() for l in losses])
 
     print("Epoch %d: Loss: %.3f, Time %.1f sec" % (
-        epoch, train_loss/len(train_data)/batch_size, time()-tic))
+        epoch, train_loss/len(train_data), time()-tic))
 ```


### PR DESCRIPTION
This PR mostly fixes minor typos. The latest commit changes the last code block of `use_gpus.md` so that the loss measure used there is the same as the one used in `train.md`.