### PR TITLE
Update Jenkinsfile for CI server conda upgrade

### DIFF
--- a/build/build_doc.sh
+++ b/build/build_doc.sh
@@ -7,7 +7,7 @@ set -e
 
 # prepare the env
 conda env update -f build/build.yml
-source activate gluon_crash_course
+conda activate gluon_crash_course
 
 pip list
 


### PR DESCRIPTION
Starting with conda v4.4, `source activate` is discouraged. The CI server now runs conda 4.5 so the Jenkinsfile needs to be adapted.