### PR TITLE
update for latest MXNet installation info

### DIFF
--- a/mxnet_packages.md
+++ b/mxnet_packages.md
@@ -29,10 +29,10 @@ All MXNet packages can be found at
 ### Nvidia GPUs
 
 To run on Nvidia GPUs, we should install a package with `cu??` in the package
-name, where `??` is CUDA version such as `80` and `91`. To install such as
+name, where `??` is CUDA version such as `80` and `91`. To install a specific
 version, users should have [CUDA](https://developer.nvidia.com/cuda-downloads)
-installed first. Then according to the CUDA version, which can be checked by
-`nvcc --version`, to select the proper package.
+installed first. Then select the MXNet package that matches the CUDA version.
+This can be checked by running `nvcc -V`.
 
 ```eval_rst
 
@@ -43,21 +43,22 @@ CUDA version  MXNet package
 8.0           ``mxnet-cu80``
 9.0           ``mxnet-cu90``
 9.1           ``mxnet-cu91``
+9.2           ``mxnet-cu92``
 ============  ===============
 
 ```
 
-All `cu` packages ship `cudnn` in default, there is no need to install it
+All `cu` packages ship with `cudnn` by default, so there is no need to install it
 separately.
 
-A common error to use the `cu` packages is failed to open CUDA shared objects
-after `import mxnet`, such as
+A common error with the `cu` packages is when CUDA shared objects fail to open
+after using `import mxnet`. One example is:
 
 ```
 OSError: libcudart.so.9.0: cannot open shared object file: No such file or directory
 ```
 
-To solve, we just need to add CUDA into the library path, such as on Linux, we can run
+To solve, we just need to add CUDA into the library path. On Linux, we can run:
 
 ```bash
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda-9.0/lib64
@@ -66,16 +67,21 @@ export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda-9.0/lib64
 ### Intel CPUs
 
 All MXNet packages support Intel CPUs, but the variants with `mkl` in the
-package name can potentially improve the performance. For example, for
+package name can potentially improve the performance. These packages have
+Intel's [MKL-DNN](https://github.com/intel/mkl-dnn) included. For example, for
 convolutional neural network inference, `mxnet-mkl` often outperforms `mxnet` by
 [more than 4x](https://mxnet.incubator.apache.org/faq/perf.html#intel-cpu).
 
-But also note that `mxnet-mkl` is still experimental. You may need to roll back
-to `mxnet` if your programs are failed to run.
+You may install MXNet with MKL-DNN with the following:
+
+```bash
+pip install mxnet-mkl
+```
 
 ### Nvidia GPU + Intel CPUs
 
-We can have both hardware accelerated:
+We can have both CPU and GPU hardware accelerated by using CUDA and MKL-DNN.
+Use one of the following package options:
 
 
 ```eval_rst
@@ -87,26 +93,27 @@ CUDA version  MXNet package
 8.0           ``mxnet-cu80mkl``
 9.0           ``mxnet-cu90mkl``
 9.1           ``mxnet-cu91mkl``
+9.2           ``mxnet-cu92mkl``
 ============  ==================
 
 ```
 
 ## Upgrade to the newest version
 
-MXNet often makes a major release in one or two months. In addition, it releases
-nightly builds every day. Some toolkits or tutorials require the newest version,
-which can be installed or upgraded through the `--pre` flag.
+MXNet makes a major release every one or two months. In addition, it releases
+nightly builds every day. Some toolkits or tutorials require the newest version.
+This can be installed or upgraded using the `--pre` flag.
 
-Install the nightly build MXNet with CUDA 9.1:
+Install the nightly build MXNet with CUDA 9.2:
 
 ```bash
-pip install --pre mxnet-cu91
+pip install --pre mxnet-cu92
 ```
 
 or upgrade the version with `-U`:
 
 ```bash
-pip install --pre -U mxnet-cu91
+pip install --pre -U mxnet-cu92
 ```
 
 


### PR DESCRIPTION
This PR updates several things about the installation of MXNet:
* adds the `cu92` flavors
* removes the experimental comment about the MKL packages
* pip install example for mxnet-mkl
* grammatical fixes